### PR TITLE
Add spec for de only config

### DIFF
--- a/blsqpy/mapping.py
+++ b/blsqpy/mapping.py
@@ -42,6 +42,7 @@ def to_mappings(activity, activity_code):
 def map_from_activity(df, activity, activity_code, drop_intermediate=True):
 
     mappings = to_mappings(activity, activity_code)
+    columns_to_drop = []
     # make sure columns exists even if no data
     for de, column in mappings.items():
         if de not in df.columns:
@@ -54,11 +55,12 @@ def map_from_activity(df, activity, activity_code, drop_intermediate=True):
                     df[column] = pd.to_numeric(df[column],errors='ignore', downcast='float')
                 print("WARN implicit aggregation for ", de," from ", child_de_cols)
                 df[de] =df[child_de_cols].sum(axis=1, min_count=1)
-            #Otherwise create an empty column                
+                columns_to_drop.extend(child_de_cols)
+            #Otherwise create an empty column
             else:
                 print("WARN adding empty column for", de, column)
                 df[de] = np.nan
-            
+
     df = df.rename(index=str, columns=mappings)
 
     # make sure we consider these a numerics, or + eval will concatenate instead of summing
@@ -74,5 +76,8 @@ def map_from_activity(df, activity, activity_code, drop_intermediate=True):
         df[column] = df[columns_to_sum].sum(axis=1, min_count=1)
         if drop_intermediate:
             df.drop(columns_to_sum, axis=1, inplace=True)
+
+    if drop_intermediate:
+        df.drop(columns_to_drop, axis=1, inplace=True)
 
     return df

--- a/specs/fixtures/config/sample_with_only_de.json
+++ b/specs/fixtures/config/sample_with_only_de.json
@@ -1,0 +1,16 @@
+{
+  "activities": {
+    "pills": {
+      "name": "Pilule",
+      "states": {
+        "aggregated": {
+          "sources": {
+            "moh": {
+              "uids": ["s4CxsmoqdRj"]
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/specs/fixtures/extract/rotated_with_only_de.csv
+++ b/specs/fixtures/extract/rotated_with_only_de.csv
@@ -1,0 +1,4 @@
+period,orgunit,uidlevel3,uidlevel2,s4CxsmoqdRj.oFtySBIkit2,s4CxsmoqdRj.pQqm0IZ6AJ3,s4CxsmoqdRj.Vkfh73dsruW
+201810,ADlqHWi5XoF,C45N74moRRQ,S9nVJLlzYrK,,,
+201810,G93DKvb6AoO,wtfYrXHHiL5,S9nVJLlzYrK,5.0,4.0,6.0
+201810,Lfne3gUweGX,wtfYrXHHiL5,S9nVJLlzYrK,8.0,2.0,1.0

--- a/specs/fixtures/mapping/mapped_with_only_de.csv
+++ b/specs/fixtures/mapping/mapped_with_only_de.csv
@@ -1,0 +1,4 @@
+period,orgunit,uidlevel3,uidlevel2,s4CxsmoqdRj.oFtySBIkit2,s4CxsmoqdRj.pQqm0IZ6AJ3,s4CxsmoqdRj.Vkfh73dsruW,pills_aggregated_moh
+201810,ADlqHWi5XoF,C45N74moRRQ,S9nVJLlzYrK,,,,
+201810,G93DKvb6AoO,wtfYrXHHiL5,S9nVJLlzYrK,5.0,4.0,6.0,15.0
+201810,Lfne3gUweGX,wtfYrXHHiL5,S9nVJLlzYrK,8.0,2.0,1.0,11.0

--- a/specs/fixtures/mapping/mapped_with_only_de.csv
+++ b/specs/fixtures/mapping/mapped_with_only_de.csv
@@ -1,4 +1,4 @@
-period,orgunit,uidlevel3,uidlevel2,s4CxsmoqdRj.oFtySBIkit2,s4CxsmoqdRj.pQqm0IZ6AJ3,s4CxsmoqdRj.Vkfh73dsruW,pills_aggregated_moh
-201810,ADlqHWi5XoF,C45N74moRRQ,S9nVJLlzYrK,,,,
-201810,G93DKvb6AoO,wtfYrXHHiL5,S9nVJLlzYrK,5.0,4.0,6.0,15.0
-201810,Lfne3gUweGX,wtfYrXHHiL5,S9nVJLlzYrK,8.0,2.0,1.0,11.0
+period,orgunit,uidlevel3,uidlevel2,pills_aggregated_moh
+201810,ADlqHWi5XoF,C45N74moRRQ,S9nVJLlzYrK,
+201810,G93DKvb6AoO,wtfYrXHHiL5,S9nVJLlzYrK,15.0
+201810,Lfne3gUweGX,wtfYrXHHiL5,S9nVJLlzYrK,11.0

--- a/specs/mapping_spec.py
+++ b/specs/mapping_spec.py
@@ -10,7 +10,27 @@ from collections import OrderedDict
 config = Descriptor.load("./specs/fixtures/config/sample")
 
 
+def test_from_rotated_to_mapped(config, rotated_csv, mapped_csv):
+    df = pd.read_csv("./specs/fixtures/extract/"+rotated_csv, sep=',')
+    mapped_df = mapping.map_from_activity(
+        df, config.activities.pills, "pills")
+    print(df)
+    print("*************** mapped_df")
+    print(mapped_df)
+
+    #mapped_df.to_csv("./specs/mapping/mapped.csv", sep=',')
+    expected_mapped = pd.read_csv(
+        "./specs/fixtures/mapping/"+mapped_csv, sep=',')
+    print("*************** expected_mapped")
+    print(expected_mapped)
+
+    assert_frame_equal(
+        mapped_df.reset_index(drop=True),
+        expected_mapped,
+        check_dtype=False)
+
 with description('mapping') as self:
+
     with it('build mapping when multiple uuid'):
         expect(mapping.to_mappings(config.activities.pills, "pills")).to(
             equal(OrderedDict([
@@ -30,19 +50,8 @@ with description('mapping') as self:
             ]}))
 
     with it('maps a dataframe with from coc.de to activity_state_source columns'):
-        df = pd.read_csv("./specs/fixtures/extract/rotated.csv", sep=',')
-        mapped_df = mapping.map_from_activity(
-            df, config.activities.pills, "pills")
-        print(df)
-        print("*************** mapped_df")
-        print(mapped_df)
+        test_from_rotated_to_mapped(config, 'rotated.csv', 'mapped.csv')
 
-        #mapped_df.to_csv("./specs/mapping/mapped.csv", sep=',')
-        expected_mapped = pd.read_csv("./specs/fixtures/mapping/mapped.csv", sep=',')
-        print("*************** expected_mapped")
-        print(expected_mapped)
-
-        assert_frame_equal(
-            mapped_df.reset_index(drop=True),
-            expected_mapped,
-            check_dtype=False)
+    with it('maps a dataframe with from coc.* to activity_state_source column when not category combo option is provided'):
+        config = Descriptor.load("./specs/fixtures/config/sample_with_only_de")
+        test_from_rotated_to_mapped(config, 'rotated_with_only_de.csv', 'mapped_with_only_de.csv')


### PR DESCRIPTION
I've added a spec where the config only specifies the de (and not "de.coc_id")
I'm also removing the columns that were summed up.

as the 2 spec were really similar I've create a shared function