### PR TITLE
Allow to normalize names for states

### DIFF
--- a/blsqpy/descriptor.py
+++ b/blsqpy/descriptor.py
@@ -2,17 +2,69 @@
 
 import json
 from collections import namedtuple
+from collections import OrderedDict
+import re
+import unicodedata
+
+
+def parameterize(string_to_clean, sep='_'):
+
+    parameterized_string = unicodedata.normalize(
+        'NFKD', string_to_clean).encode('ASCII', 'ignore').decode()
+    parameterized_string = parameterized_string.replace("(", "_", -1)
+    parameterized_string = parameterized_string.replace(")", "_", -1)
+    parameterized_string = parameterized_string.replace("/", "_", -1)
+    parameterized_string = parameterized_string.replace("-", "_", -1)
+    parameterized_string = parameterized_string.replace("-", "_", -1)
+    parameterized_string = parameterized_string.replace("+", "_", -1)
+    parameterized_string = parameterized_string.replace("_", "_", -1)
+    # Remove all non-word characters (everything except numbers and letters)
+    parameterized_string = re.sub(r"[^\w\s]", '', parameterized_string)
+
+    # Replace all runs of whitespace with a single dash
+    parameterized_string = re.sub(r"\s+", '_', parameterized_string)
+    parameterized_string = re.sub('\_+', '_', parameterized_string)
+    return parameterized_string.lower().rstrip('_')
+
+
+def as_named_tuple(d):
+    return namedtuple(
+        'X'+"__".join(map(parameterize, d.keys())),
+        map(parameterize, d.keys()))(*d.values())
+
+
+def as_legacy_named_tuple(d):
+    return namedtuple('X'+"__".join(d.keys()), d.keys())(*d.values())
 
 
 class Descriptor():
     @staticmethod
-    def load(name):
+    def load(name, tuple_function= as_named_tuple):
         with open(name+".json", encoding='utf-8') as f:
-            return json.loads(f.read(), object_hook=lambda d: namedtuple('X'+"__".join(d.keys()), d.keys())(*d.values()))
+            return json.loads(
+                f.read(), object_hook=tuple_function)
+
     @staticmethod
-    def load_string(content):
-        return json.loads(content, object_hook=lambda d: namedtuple('X'+"__".join(d.keys()), d.keys())(*d.values()))
+    def load_string(content, tuple_function= as_named_tuple):
+        return json.loads(
+            content,
+            object_hook=tuple_function)
 
     @staticmethod
     def as_items(collection):
         return sorted(collection._asdict().items())
+
+    @staticmethod
+    def to_json(config):
+        def recursive_to_json(obj):
+            _json = OrderedDict()
+
+            if isinstance(obj, tuple):
+                datas = obj._asdict()
+                for data in datas:
+                    if isinstance(datas[data], tuple):
+                        _json[data] = (recursive_to_json(datas[data]))
+                    else:
+                        _json[data] = (datas[data])
+            return _json
+        return json.dumps(recursive_to_json(config), indent=4)

--- a/specs/descriptor_spec.py
+++ b/specs/descriptor_spec.py
@@ -1,11 +1,27 @@
 
 from mamba import description, context, it
 from expects import expect, equal
-
+import json
 from blsqpy.descriptor import Descriptor
+
+
+def json_fixture_content(filename):
+    print("reading", filename)
+    with open(filename+".json", encoding='utf-8') as f:
+        return json.loads(f.read())
 
 
 with description('Parsing json config') as self:
     with it('loads them as namedTupples'):
         config = Descriptor.load("./specs/fixtures/config/demo")
         expect(config.demo.test.hello).to(equal("world"))
+
+    with it('loads them as namedTupples and normalize states'):
+        config = Descriptor.load("./specs/fixtures/config/parametrized-raw")
+        jsonDescriptor = Descriptor.to_json(config)
+        print(jsonDescriptor)
+        expect(json.loads(jsonDescriptor)).to(
+            equal(
+                json_fixture_content(
+                    "./specs/fixtures/config/parametrized-final"))
+        )

--- a/specs/fixtures/config/parametrized-final.json
+++ b/specs/fixtures/config/parametrized-final.json
@@ -1,0 +1,1041 @@
+{
+    "settings": {
+        "dhis2_connection_id": "dhis"
+    },
+    "activities": {
+        "hiv_analysis": {
+            "name": "HIV treatment lines summary",
+            "states": {
+                "data_nvp_200_mg_60_ces_stockout": {
+                    "sources": {
+                        "blsq": {
+                            "uids": [
+                                "c2cqb8QtJ1S"
+                            ]
+                        }
+                    },
+                    "reconcile_options": {
+                        "comments": [
+                            ""
+                        ],
+                        "preferred_source": "blsq",
+                        "data_type": "flux",
+                        "impute": {}
+                    }
+                },
+                "azt_3tc_efv": {
+                    "sources": {
+                        "cordaid": {
+                            "uids": [
+                                "ppV5TCX4Nd4"
+                            ]
+                        },
+                        "pnls": {
+                            "uids": [
+                                "uIvFJy1ZSMC"
+                            ]
+                        }
+                    },
+                    "reconcile_options": {
+                        "comments": [
+                            ""
+                        ],
+                        "preferred_source": "cordaid",
+                        "data_type": "flux",
+                        "impute": {}
+                    }
+                },
+                "data_tdf_300_mg_30_ces_stockout": {
+                    "sources": {
+                        "blsq": {
+                            "uids": [
+                                "XFwCquySY0I"
+                            ]
+                        }
+                    },
+                    "reconcile_options": {
+                        "comments": [
+                            ""
+                        ],
+                        "preferred_source": "blsq",
+                        "data_type": "flux",
+                        "impute": {}
+                    }
+                },
+                "data_3tc_150_mg_60_ces_stockout": {
+                    "sources": {
+                        "blsq": {
+                            "uids": [
+                                "F1odQwWvLlM"
+                            ]
+                        }
+                    },
+                    "reconcile_options": {
+                        "comments": [
+                            ""
+                        ],
+                        "preferred_source": "blsq",
+                        "data_type": "flux",
+                        "impute": {}
+                    }
+                },
+                "abc_3tc_efv": {
+                    "sources": {
+                        "cordaid": {
+                            "uids": [
+                                "vPLs3m92srh"
+                            ]
+                        },
+                        "pnls": {
+                            "uids": [
+                                "lttU7PiCAqg"
+                            ]
+                        }
+                    },
+                    "reconcile_options": {
+                        "comments": [
+                            ""
+                        ],
+                        "preferred_source": "cordaid",
+                        "data_type": "flux",
+                        "impute": {}
+                    }
+                },
+                "data_lpv_r_100_25_mg_ces_60_ces_stockout": {
+                    "sources": {
+                        "blsq": {
+                            "uids": [
+                                "XgCWDfRv5Rq"
+                            ]
+                        }
+                    },
+                    "reconcile_options": {
+                        "comments": [
+                            ""
+                        ],
+                        "preferred_source": "blsq",
+                        "data_type": "flux",
+                        "impute": {}
+                    }
+                },
+                "data_efv_600_mg_30_ces_consommation_moyenne_ajustee": {
+                    "sources": {
+                        "blsq": {
+                            "uids": [
+                                "lYuAeFMju4R"
+                            ]
+                        }
+                    },
+                    "reconcile_options": {
+                        "comments": [
+                            ""
+                        ],
+                        "preferred_source": "blsq",
+                        "data_type": "flux",
+                        "impute": {}
+                    }
+                },
+                "azt_3tc_nvp": {
+                    "sources": {
+                        "cordaid": {
+                            "uids": [
+                                "wrRjiD0fz8j"
+                            ]
+                        },
+                        "pnls": {
+                            "uids": [
+                                "hHahC0WTLlX"
+                            ]
+                        }
+                    },
+                    "reconcile_options": {
+                        "comments": [
+                            ""
+                        ],
+                        "preferred_source": "cordaid",
+                        "data_type": "flux",
+                        "impute": {}
+                    }
+                },
+                "data_azt_300_mg_60_ces_consommation_moyenne_ajustee": {
+                    "sources": {
+                        "blsq": {
+                            "uids": [
+                                "cKmRQv2XGs6"
+                            ]
+                        }
+                    },
+                    "reconcile_options": {
+                        "comments": [
+                            ""
+                        ],
+                        "preferred_source": "blsq",
+                        "data_type": "flux",
+                        "impute": {}
+                    }
+                },
+                "data_abc_3tc_300_150_mg_60_ces_stockout": {
+                    "sources": {
+                        "blsq": {
+                            "uids": [
+                                "k3yh51eXltE"
+                            ]
+                        }
+                    },
+                    "reconcile_options": {
+                        "comments": [
+                            ""
+                        ],
+                        "preferred_source": "blsq",
+                        "data_type": "flux",
+                        "impute": {}
+                    }
+                },
+                "data_tdf_3tc_300_300_mg_30_ces_stockout": {
+                    "sources": {
+                        "blsq": {
+                            "uids": [
+                                "uJwJ6MNvPDf"
+                            ]
+                        }
+                    },
+                    "reconcile_options": {
+                        "comments": [
+                            ""
+                        ],
+                        "preferred_source": "blsq",
+                        "data_type": "flux",
+                        "impute": {}
+                    }
+                },
+                "data_tdf_3tc_300_300_mg_30_ces_consommation_moyenne_ajustee": {
+                    "sources": {
+                        "blsq": {
+                            "uids": [
+                                "TduLijG7QLO"
+                            ]
+                        }
+                    },
+                    "reconcile_options": {
+                        "comments": [
+                            ""
+                        ],
+                        "preferred_source": "blsq",
+                        "data_type": "flux",
+                        "impute": {}
+                    }
+                },
+                "data_azt_3tc_300_150_mg_60_ces_consommation_moyenne_ajustee": {
+                    "sources": {
+                        "blsq": {
+                            "uids": [
+                                "Pg1NN5I7afb"
+                            ]
+                        }
+                    },
+                    "reconcile_options": {
+                        "comments": [
+                            ""
+                        ],
+                        "preferred_source": "blsq",
+                        "data_type": "flux",
+                        "impute": {}
+                    }
+                },
+                "data_nvp_200_mg_60_ces_consommation_moyenne_ajustee": {
+                    "sources": {
+                        "blsq": {
+                            "uids": [
+                                "NPlgyBSw8uu"
+                            ]
+                        }
+                    },
+                    "reconcile_options": {
+                        "comments": [
+                            ""
+                        ],
+                        "preferred_source": "blsq",
+                        "data_type": "flux",
+                        "impute": {}
+                    }
+                },
+                "data_azt_3tc_nvp_300_150_200_mg_60_ces_stockout": {
+                    "sources": {
+                        "blsq": {
+                            "uids": [
+                                "d7bv8JQg5MM"
+                            ]
+                        }
+                    },
+                    "reconcile_options": {
+                        "comments": [
+                            ""
+                        ],
+                        "preferred_source": "blsq",
+                        "data_type": "flux",
+                        "impute": {}
+                    }
+                },
+                "abc_3tc_lpv_r": {
+                    "sources": {
+                        "cordaid": {
+                            "uids": [
+                                "pnmoOGpFyIa"
+                            ]
+                        },
+                        "pnls": {
+                            "uids": [
+                                "prnCi6GwYzL"
+                            ]
+                        }
+                    },
+                    "reconcile_options": {
+                        "comments": [
+                            ""
+                        ],
+                        "preferred_source": "cordaid",
+                        "data_type": "flux",
+                        "impute": {}
+                    }
+                },
+                "data_abc_3tc_300_150_mg_60_ces_consommation_moyenne_ajustee": {
+                    "sources": {
+                        "blsq": {
+                            "uids": [
+                                "PHWsepgB5t1"
+                            ]
+                        }
+                    },
+                    "reconcile_options": {
+                        "comments": [
+                            ""
+                        ],
+                        "preferred_source": "blsq",
+                        "data_type": "flux",
+                        "impute": {}
+                    }
+                },
+                "data_abc_3tc_60_30_mg_disp_60ces_stockout": {
+                    "sources": {
+                        "blsq": {
+                            "uids": [
+                                "mZ4Xxqlyovd"
+                            ]
+                        }
+                    },
+                    "reconcile_options": {
+                        "comments": [
+                            ""
+                        ],
+                        "preferred_source": "blsq",
+                        "data_type": "flux",
+                        "impute": {}
+                    }
+                },
+                "tdf_ftc_lpv_rt": {
+                    "sources": {
+                        "cordaid": {
+                            "uids": [
+                                "yOCXFpdC8pm"
+                            ]
+                        }
+                    },
+                    "reconcile_options": {
+                        "comments": [
+                            ""
+                        ],
+                        "preferred_source": "cordaid",
+                        "data_type": "flux",
+                        "impute": {}
+                    }
+                },
+                "data_lpv_r_80_20_mg_ml_solution_orale_fl_60_ml_consommation_moyenne_ajustee": {
+                    "sources": {
+                        "blsq": {
+                            "uids": [
+                                "Ef1j9aizOQx"
+                            ]
+                        }
+                    },
+                    "reconcile_options": {
+                        "comments": [
+                            ""
+                        ],
+                        "preferred_source": "blsq",
+                        "data_type": "flux",
+                        "impute": {}
+                    }
+                },
+                "data_tdf_ftc_300_200_mg_30_ces_stockout": {
+                    "sources": {
+                        "blsq": {
+                            "uids": [
+                                "vfBVUBSpqyO"
+                            ]
+                        }
+                    },
+                    "reconcile_options": {
+                        "comments": [
+                            ""
+                        ],
+                        "preferred_source": "blsq",
+                        "data_type": "flux",
+                        "impute": {}
+                    }
+                },
+                "data_tdf_300_mg_30_ces_consommation_moyenne_ajustee": {
+                    "sources": {
+                        "blsq": {
+                            "uids": [
+                                "RHG92O0jpbG"
+                            ]
+                        }
+                    },
+                    "reconcile_options": {
+                        "comments": [
+                            ""
+                        ],
+                        "preferred_source": "blsq",
+                        "data_type": "flux",
+                        "impute": {}
+                    }
+                },
+                "data_azt_3tc_nvp_60_30_50_mg_ces_disp_60_ces_stockout": {
+                    "sources": {
+                        "blsq": {
+                            "uids": [
+                                "Iiw7a7JBshL"
+                            ]
+                        }
+                    },
+                    "reconcile_options": {
+                        "comments": [
+                            ""
+                        ],
+                        "preferred_source": "blsq",
+                        "data_type": "flux",
+                        "impute": {}
+                    }
+                },
+                "data_3tc_150_mg_60_ces_consommation_moyenne_ajustee": {
+                    "sources": {
+                        "blsq": {
+                            "uids": [
+                                "kJB5oI2nBuN"
+                            ]
+                        }
+                    },
+                    "reconcile_options": {
+                        "comments": [
+                            ""
+                        ],
+                        "preferred_source": "blsq",
+                        "data_type": "flux",
+                        "impute": {}
+                    }
+                },
+                "autres_a_preciser": {
+                    "sources": {
+                        "cordaid": {
+                            "uids": [
+                                "sQz9CgzwqVH"
+                            ]
+                        },
+                        "pnls": {
+                            "uids": [
+                                "X2nhX2N5B0B"
+                            ]
+                        }
+                    },
+                    "reconcile_options": {
+                        "comments": [
+                            ""
+                        ],
+                        "preferred_source": "cordaid",
+                        "data_type": "flux",
+                        "impute": {}
+                    }
+                },
+                "data_3tc_10_mg_ml_solution_orale_fl_240_ml_consommation_moyenne_ajustee": {
+                    "sources": {
+                        "blsq": {
+                            "uids": [
+                                "R6YWian9QTi"
+                            ]
+                        }
+                    },
+                    "reconcile_options": {
+                        "comments": [
+                            ""
+                        ],
+                        "preferred_source": "blsq",
+                        "data_type": "flux",
+                        "impute": {}
+                    }
+                },
+                "data_lpv_r_80_20_mg_ml_solution_orale_fl_60_ml_stockout": {
+                    "sources": {
+                        "blsq": {
+                            "uids": [
+                                "LoQMve1V1l8"
+                            ]
+                        }
+                    },
+                    "reconcile_options": {
+                        "comments": [
+                            ""
+                        ],
+                        "preferred_source": "blsq",
+                        "data_type": "flux",
+                        "impute": {}
+                    }
+                },
+                "data_abc_3tc_60_30_mg_disp_60ces_consommation_moyenne_ajustee": {
+                    "sources": {
+                        "blsq": {
+                            "uids": [
+                                "ouXrR8dJByP"
+                            ]
+                        }
+                    },
+                    "reconcile_options": {
+                        "comments": [
+                            ""
+                        ],
+                        "preferred_source": "blsq",
+                        "data_type": "flux",
+                        "impute": {}
+                    }
+                },
+                "data_azt_3tc_nvp_60_30_50_mg_ces_disp_60_ces_consommation_moyenne_ajustee": {
+                    "sources": {
+                        "blsq": {
+                            "uids": [
+                                "jt5sDQ4CqWQ"
+                            ]
+                        }
+                    },
+                    "reconcile_options": {
+                        "comments": [
+                            ""
+                        ],
+                        "preferred_source": "blsq",
+                        "data_type": "flux",
+                        "impute": {}
+                    }
+                },
+                "data_lpv_r_200_50_mg_12o_ces_stockout": {
+                    "sources": {
+                        "blsq": {
+                            "uids": [
+                                "opaSTvEyLaW"
+                            ]
+                        }
+                    },
+                    "reconcile_options": {
+                        "comments": [
+                            ""
+                        ],
+                        "preferred_source": "blsq",
+                        "data_type": "flux",
+                        "impute": {}
+                    }
+                },
+                "tdf_3tc_efv": {
+                    "sources": {
+                        "cordaid": {
+                            "uids": [
+                                "iOW0K3mjoxe"
+                            ]
+                        },
+                        "pnls": {
+                            "uids": [
+                                "fdc1v0PSUZe"
+                            ]
+                        }
+                    },
+                    "reconcile_options": {
+                        "comments": [
+                            ""
+                        ],
+                        "preferred_source": "cordaid",
+                        "data_type": "flux",
+                        "impute": {}
+                    }
+                },
+                "data_efv_600_mg_30_ces_stockout": {
+                    "sources": {
+                        "blsq": {
+                            "uids": [
+                                "g7JxNzgGVEo"
+                            ]
+                        }
+                    },
+                    "reconcile_options": {
+                        "comments": [
+                            ""
+                        ],
+                        "preferred_source": "blsq",
+                        "data_type": "flux",
+                        "impute": {}
+                    }
+                },
+                "data_azt_3tc_nvp_300_150_200_mg_60_ces_consommation_moyenne_ajustee": {
+                    "sources": {
+                        "blsq": {
+                            "uids": [
+                                "XCTlZSrQueT"
+                            ]
+                        }
+                    },
+                    "reconcile_options": {
+                        "comments": [
+                            ""
+                        ],
+                        "preferred_source": "blsq",
+                        "data_type": "flux",
+                        "impute": {}
+                    }
+                },
+                "tdf_ftc_efv": {
+                    "sources": {
+                        "cordaid": {
+                            "uids": [
+                                "UghM3Ucwecy"
+                            ]
+                        },
+                        "pnls": {
+                            "uids": [
+                                "pidcOIMv6Er"
+                            ]
+                        }
+                    },
+                    "reconcile_options": {
+                        "comments": [
+                            ""
+                        ],
+                        "preferred_source": "cordaid",
+                        "data_type": "flux",
+                        "impute": {}
+                    }
+                },
+                "data_lvp_r_133_33_mg_120_ces_consommation_moyenne_ajustee": {
+                    "sources": {
+                        "blsq": {
+                            "uids": [
+                                "C8sKB4jQhF9"
+                            ]
+                        }
+                    },
+                    "reconcile_options": {
+                        "comments": [
+                            ""
+                        ],
+                        "preferred_source": "blsq",
+                        "data_type": "flux",
+                        "impute": {}
+                    }
+                },
+                "azt_3tc_lpv_r": {
+                    "sources": {
+                        "cordaid": {
+                            "uids": [
+                                "CEWPwSNogdU"
+                            ]
+                        },
+                        "pnls": {
+                            "uids": [
+                                "WTfY6gHxkKe"
+                            ]
+                        }
+                    },
+                    "reconcile_options": {
+                        "comments": [
+                            ""
+                        ],
+                        "preferred_source": "cordaid",
+                        "data_type": "flux",
+                        "impute": {}
+                    }
+                },
+                "data_tdf_3tc_efv_300_300_600_mg_30_ces_consommation_moyenne_ajustee": {
+                    "sources": {
+                        "blsq": {
+                            "uids": [
+                                "HiERwOmAgjz"
+                            ]
+                        }
+                    },
+                    "reconcile_options": {
+                        "comments": [
+                            ""
+                        ],
+                        "preferred_source": "blsq",
+                        "data_type": "flux",
+                        "impute": {}
+                    }
+                },
+                "data_lpv_r_100_25_mg_ces_60_ces_consommation_moyenne_ajustee": {
+                    "sources": {
+                        "blsq": {
+                            "uids": [
+                                "Z1Jz4BLyhwa"
+                            ]
+                        }
+                    },
+                    "reconcile_options": {
+                        "comments": [
+                            ""
+                        ],
+                        "preferred_source": "blsq",
+                        "data_type": "flux",
+                        "impute": {}
+                    }
+                },
+                "data_azt_3tc_300_150_mg_60_ces_stockout": {
+                    "sources": {
+                        "blsq": {
+                            "uids": [
+                                "Y7sG2cnO6V9"
+                            ]
+                        }
+                    },
+                    "reconcile_options": {
+                        "comments": [
+                            ""
+                        ],
+                        "preferred_source": "blsq",
+                        "data_type": "flux",
+                        "impute": {}
+                    }
+                },
+                "data_abc_60_mg_disp_60_ces_stockout": {
+                    "sources": {
+                        "blsq": {
+                            "uids": [
+                                "SPbj5ZEpF8F"
+                            ]
+                        }
+                    },
+                    "reconcile_options": {
+                        "comments": [
+                            ""
+                        ],
+                        "preferred_source": "blsq",
+                        "data_type": "flux",
+                        "impute": {}
+                    }
+                },
+                "data_nvp_50_mg_ces_pour_solution_orale_60_ces_stockout": {
+                    "sources": {
+                        "blsq": {
+                            "uids": [
+                                "IIhBVdKSRhK"
+                            ]
+                        }
+                    },
+                    "reconcile_options": {
+                        "comments": [
+                            ""
+                        ],
+                        "preferred_source": "blsq",
+                        "data_type": "flux",
+                        "impute": {}
+                    }
+                },
+                "data_nvp_50_mg_ces_pour_solution_orale_60_ces_consommation_moyenne_ajustee": {
+                    "sources": {
+                        "blsq": {
+                            "uids": [
+                                "v9hr0FNP5ZV"
+                            ]
+                        }
+                    },
+                    "reconcile_options": {
+                        "comments": [
+                            ""
+                        ],
+                        "preferred_source": "blsq",
+                        "data_type": "flux",
+                        "impute": {}
+                    }
+                },
+                "abc_3tc_nvp": {
+                    "sources": {
+                        "cordaid": {
+                            "uids": [
+                                "LgElMKG231h"
+                            ]
+                        },
+                        "pnls": {
+                            "uids": [
+                                "X6ROVclhfqF"
+                            ]
+                        }
+                    },
+                    "reconcile_options": {
+                        "comments": [
+                            ""
+                        ],
+                        "preferred_source": "cordaid",
+                        "data_type": "flux",
+                        "impute": {}
+                    }
+                },
+                "data_3tc_10_mg_ml_solution_orale_fl_240_ml_stockout": {
+                    "sources": {
+                        "blsq": {
+                            "uids": [
+                                "JtizQc3ItvD"
+                            ]
+                        }
+                    },
+                    "reconcile_options": {
+                        "comments": [
+                            ""
+                        ],
+                        "preferred_source": "blsq",
+                        "data_type": "flux",
+                        "impute": {}
+                    }
+                },
+                "data_abc_300_mg_60_ces_consommation_moyenne_ajustee": {
+                    "sources": {
+                        "blsq": {
+                            "uids": [
+                                "qHppnoWi4M4"
+                            ]
+                        }
+                    },
+                    "reconcile_options": {
+                        "comments": [
+                            ""
+                        ],
+                        "preferred_source": "blsq",
+                        "data_type": "flux",
+                        "impute": {}
+                    }
+                },
+                "tdf_ftc_nvp": {
+                    "sources": {
+                        "cordaid": {
+                            "uids": [
+                                "VH5BEHHJFIs"
+                            ]
+                        },
+                        "pnls": {
+                            "uids": [
+                                "fiEARR6fRnJ"
+                            ]
+                        }
+                    },
+                    "reconcile_options": {
+                        "comments": [
+                            ""
+                        ],
+                        "preferred_source": "cordaid",
+                        "data_type": "flux",
+                        "impute": {}
+                    }
+                },
+                "data_lvp_r_133_33_mg_120_ces_stockout": {
+                    "sources": {
+                        "blsq": {
+                            "uids": [
+                                "LcnTFQ7pIX0"
+                            ]
+                        }
+                    },
+                    "reconcile_options": {
+                        "comments": [
+                            ""
+                        ],
+                        "preferred_source": "blsq",
+                        "data_type": "flux",
+                        "impute": {}
+                    }
+                },
+                "tdf_3tc_nvp": {
+                    "sources": {
+                        "cordaid": {
+                            "uids": [
+                                "lqA1LfMt9C6"
+                            ]
+                        },
+                        "pnls": {
+                            "uids": [
+                                "Q71tylkcq2P"
+                            ]
+                        }
+                    },
+                    "reconcile_options": {
+                        "comments": [
+                            ""
+                        ],
+                        "preferred_source": "cordaid",
+                        "data_type": "flux",
+                        "impute": {}
+                    }
+                },
+                "data_tdf_ftc_300_200_mg_30_ces_consommation_moyenne_ajustee": {
+                    "sources": {
+                        "blsq": {
+                            "uids": [
+                                "lcQMOUBuDc5"
+                            ]
+                        }
+                    },
+                    "reconcile_options": {
+                        "comments": [
+                            ""
+                        ],
+                        "preferred_source": "blsq",
+                        "data_type": "flux",
+                        "impute": {}
+                    }
+                },
+                "data_azt_3tc_60_30_mg_ces_disp_60ces_consommation_moyenne_ajustee": {
+                    "sources": {
+                        "blsq": {
+                            "uids": [
+                                "gCGaBeegAxW"
+                            ]
+                        }
+                    },
+                    "reconcile_options": {
+                        "comments": [
+                            ""
+                        ],
+                        "preferred_source": "blsq",
+                        "data_type": "flux",
+                        "impute": {}
+                    }
+                },
+                "data_tdf_3tc_efv_300_300_600_mg_30_ces_stockout": {
+                    "sources": {
+                        "blsq": {
+                            "uids": [
+                                "hGCNPoGVKVN"
+                            ]
+                        }
+                    },
+                    "reconcile_options": {
+                        "comments": [
+                            ""
+                        ],
+                        "preferred_source": "blsq",
+                        "data_type": "flux",
+                        "impute": {}
+                    }
+                },
+                "data_azt_300_mg_60_ces_stockout": {
+                    "sources": {
+                        "blsq": {
+                            "uids": [
+                                "IwiJuJrDzjL"
+                            ]
+                        }
+                    },
+                    "reconcile_options": {
+                        "comments": [
+                            ""
+                        ],
+                        "preferred_source": "blsq",
+                        "data_type": "flux",
+                        "impute": {}
+                    }
+                },
+                "data_lpv_r_200_50_mg_12o_ces_consommation_moyenne_ajustee": {
+                    "sources": {
+                        "blsq": {
+                            "uids": [
+                                "WkeeJ5BzjCR"
+                            ]
+                        }
+                    },
+                    "reconcile_options": {
+                        "comments": [
+                            ""
+                        ],
+                        "preferred_source": "blsq",
+                        "data_type": "flux",
+                        "impute": {}
+                    }
+                },
+                "data_abc_60_mg_disp_60_ces_consommation_moyenne_ajustee": {
+                    "sources": {
+                        "blsq": {
+                            "uids": [
+                                "ZHUuHX5VAkr"
+                            ]
+                        }
+                    },
+                    "reconcile_options": {
+                        "comments": [
+                            ""
+                        ],
+                        "preferred_source": "blsq",
+                        "data_type": "flux",
+                        "impute": {}
+                    }
+                },
+                "data_abc_300_mg_60_ces_stockout": {
+                    "sources": {
+                        "blsq": {
+                            "uids": [
+                                "mvsxvsk4fTQ"
+                            ]
+                        }
+                    },
+                    "reconcile_options": {
+                        "comments": [
+                            ""
+                        ],
+                        "preferred_source": "blsq",
+                        "data_type": "flux",
+                        "impute": {}
+                    }
+                },
+                "data_azt_3tc_60_30_mg_ces_disp_60ces_stockout": {
+                    "sources": {
+                        "blsq": {
+                            "uids": [
+                                "aqvnaPyYDoY"
+                            ]
+                        }
+                    },
+                    "reconcile_options": {
+                        "comments": [
+                            ""
+                        ],
+                        "preferred_source": "blsq",
+                        "data_type": "flux",
+                        "impute": {}
+                    }
+                },
+                "tdf_3tc_lpv_r": {
+                    "sources": {
+                        "cordaid": {
+                            "uids": [
+                                "MelhgtoRH9R"
+                            ]
+                        },
+                        "pnls": {
+                            "uids": [
+                                "wLBRFksBtou"
+                            ]
+                        }
+                    },
+                    "reconcile_options": {
+                        "comments": [
+                            ""
+                        ],
+                        "preferred_source": "cordaid",
+                        "data_type": "flux",
+                        "impute": {}
+                    }
+                }
+            }
+        }
+    }
+}

--- a/specs/fixtures/config/parametrized-raw.json
+++ b/specs/fixtures/config/parametrized-raw.json
@@ -1,0 +1,559 @@
+{
+  "settings": { "dhis2_connection_id": "dhis" },
+  "activities": {
+    "hiv_analysis": {
+      "name": "HIV treatment lines summary",
+      "states": {
+        "ABC + 3TC + EFV": {
+          "sources": {
+            "cordaid": { "uids": ["vPLs3m92srh"] },
+            "pnls": { "uids": ["lttU7PiCAqg"] }
+          },
+          "reconcile_options": {
+            "preferred_source": "cordaid",
+            "data_type": "flux",
+            "impute": {},
+            "comments": [""]
+          }
+        },
+        "ABC + 3TC + LPV/r": {
+          "sources": {
+            "cordaid": { "uids": ["pnmoOGpFyIa"] },
+            "pnls": { "uids": ["prnCi6GwYzL"] }
+          },
+          "reconcile_options": {
+            "preferred_source": "cordaid",
+            "data_type": "flux",
+            "impute": {},
+            "comments": [""]
+          }
+        },
+        "ABC + 3TC + NVP": {
+          "sources": {
+            "cordaid": { "uids": ["LgElMKG231h"] },
+            "pnls": { "uids": ["X6ROVclhfqF"] }
+          },
+          "reconcile_options": {
+            "preferred_source": "cordaid",
+            "data_type": "flux",
+            "impute": {},
+            "comments": [""]
+          }
+        },
+        "Autres (\u00e0 pr\u00e9ciser)": {
+          "sources": {
+            "cordaid": { "uids": ["sQz9CgzwqVH"] },
+            "pnls": { "uids": ["X2nhX2N5B0B"] }
+          },
+          "reconcile_options": {
+            "preferred_source": "cordaid",
+            "data_type": "flux",
+            "impute": {},
+            "comments": [""]
+          }
+        },
+        "AZT + 3TC + LPV/r": {
+          "sources": {
+            "cordaid": { "uids": ["CEWPwSNogdU"] },
+            "pnls": { "uids": ["WTfY6gHxkKe"] }
+          },
+          "reconcile_options": {
+            "preferred_source": "cordaid",
+            "data_type": "flux",
+            "impute": {},
+            "comments": [""]
+          }
+        },
+        "AZT+3TC+ EFV": {
+          "sources": {
+            "cordaid": { "uids": ["ppV5TCX4Nd4"] },
+            "pnls": { "uids": ["uIvFJy1ZSMC"] }
+          },
+          "reconcile_options": {
+            "preferred_source": "cordaid",
+            "data_type": "flux",
+            "impute": {},
+            "comments": [""]
+          }
+        },
+        "AZT+3TC+NVP": {
+          "sources": {
+            "cordaid": { "uids": ["wrRjiD0fz8j"] },
+            "pnls": { "uids": ["hHahC0WTLlX"] }
+          },
+          "reconcile_options": {
+            "preferred_source": "cordaid",
+            "data_type": "flux",
+            "impute": {},
+            "comments": [""]
+          }
+        },
+        "TDF + 3TC + LPV/r": {
+          "sources": {
+            "cordaid": { "uids": ["MelhgtoRH9R"] },
+            "pnls": { "uids": ["wLBRFksBtou"] }
+          },
+          "reconcile_options": {
+            "preferred_source": "cordaid",
+            "data_type": "flux",
+            "impute": {},
+            "comments": [""]
+          }
+        },
+        "TDF + FTC + NVP": {
+          "sources": {
+            "cordaid": { "uids": ["VH5BEHHJFIs"] },
+            "pnls": { "uids": ["fiEARR6fRnJ"] }
+          },
+          "reconcile_options": {
+            "preferred_source": "cordaid",
+            "data_type": "flux",
+            "impute": {},
+            "comments": [""]
+          }
+        },
+        "TDF+ FTC + EFV": {
+          "sources": {
+            "cordaid": { "uids": ["UghM3Ucwecy"] },
+            "pnls": { "uids": ["pidcOIMv6Er"] }
+          },
+          "reconcile_options": {
+            "preferred_source": "cordaid",
+            "data_type": "flux",
+            "impute": {},
+            "comments": [""]
+          }
+        },
+        "TDF+3TC+EFV": {
+          "sources": {
+            "cordaid": { "uids": ["iOW0K3mjoxe"] },
+            "pnls": { "uids": ["fdc1v0PSUZe"] }
+          },
+          "reconcile_options": {
+            "preferred_source": "cordaid",
+            "data_type": "flux",
+            "impute": {},
+            "comments": [""]
+          }
+        },
+        "TDF+3TC+NVP": {
+          "sources": {
+            "cordaid": { "uids": ["lqA1LfMt9C6"] },
+            "pnls": { "uids": ["Q71tylkcq2P"] }
+          },
+          "reconcile_options": {
+            "preferred_source": "cordaid",
+            "data_type": "flux",
+            "impute": {},
+            "comments": [""]
+          }
+        },
+        "TDF+FTC+LPV+rt": {
+          "sources": { "cordaid": { "uids": ["yOCXFpdC8pm"] } },
+          "reconcile_options": {
+            "preferred_source": "cordaid",
+            "data_type": "flux",
+            "impute": {},
+            "comments": [""]
+          }
+        },
+        "Data-3TC 10 mg/ml solution orale - Fl. 240 ml-Consommation moyenne ajust\u00e9e": {
+          "sources": { "blsq": { "uids": ["R6YWian9QTi"] } },
+          "reconcile_options": {
+            "preferred_source": "blsq",
+            "data_type": "flux",
+            "impute": {},
+            "comments": [""]
+          }
+        },
+        "Data-3TC 150 mg - 60 ces-Consommation moyenne ajust\u00e9e": {
+          "sources": { "blsq": { "uids": ["kJB5oI2nBuN"] } },
+          "reconcile_options": {
+            "preferred_source": "blsq",
+            "data_type": "flux",
+            "impute": {},
+            "comments": [""]
+          }
+        },
+        "Data-ABC 300 mg - 60 ces-Consommation moyenne ajust\u00e9e": {
+          "sources": { "blsq": { "uids": ["qHppnoWi4M4"] } },
+          "reconcile_options": {
+            "preferred_source": "blsq",
+            "data_type": "flux",
+            "impute": {},
+            "comments": [""]
+          }
+        },
+        "Data-ABC/3TC ( 300/150 mg) - 60 ces-Consommation moyenne ajust\u00e9e": {
+          "sources": { "blsq": { "uids": ["PHWsepgB5t1"] } },
+          "reconcile_options": {
+            "preferred_source": "blsq",
+            "data_type": "flux",
+            "impute": {},
+            "comments": [""]
+          }
+        },
+        "Data-ABC /3TC 60/30 mg disp. - 60ces-Consommation moyenne ajust\u00e9e": {
+          "sources": { "blsq": { "uids": ["ouXrR8dJByP"] } },
+          "reconcile_options": {
+            "preferred_source": "blsq",
+            "data_type": "flux",
+            "impute": {},
+            "comments": [""]
+          }
+        },
+        "Data-ABC 60 mg disp - 60 ces-Consommation moyenne ajust\u00e9e": {
+          "sources": { "blsq": { "uids": ["ZHUuHX5VAkr"] } },
+          "reconcile_options": {
+            "preferred_source": "blsq",
+            "data_type": "flux",
+            "impute": {},
+            "comments": [""]
+          }
+        },
+        "Data-AZT 300 mg - 60 ces-Consommation moyenne ajust\u00e9e": {
+          "sources": { "blsq": { "uids": ["cKmRQv2XGs6"] } },
+          "reconcile_options": {
+            "preferred_source": "blsq",
+            "data_type": "flux",
+            "impute": {},
+            "comments": [""]
+          }
+        },
+        "Data-AZT/3TC (300/150 mg) - 60 ces-Consommation moyenne ajust\u00e9e": {
+          "sources": { "blsq": { "uids": ["Pg1NN5I7afb"] } },
+          "reconcile_options": {
+            "preferred_source": "blsq",
+            "data_type": "flux",
+            "impute": {},
+            "comments": [""]
+          }
+        },
+        "Data-AZT/3TC 60/30 mg ces disp - 60ces-Consommation moyenne ajust\u00e9e": {
+          "sources": { "blsq": { "uids": ["gCGaBeegAxW"] } },
+          "reconcile_options": {
+            "preferred_source": "blsq",
+            "data_type": "flux",
+            "impute": {},
+            "comments": [""]
+          }
+        },
+        "Data-AZT/3TC/NVP (300/150/200 mg) - 60 ces-Consommation moyenne ajust\u00e9e": {
+          "sources": { "blsq": { "uids": ["XCTlZSrQueT"] } },
+          "reconcile_options": {
+            "preferred_source": "blsq",
+            "data_type": "flux",
+            "impute": {},
+            "comments": [""]
+          }
+        },
+        "Data-AZT/3TC/NVP 60/30/50 mg ces disp - 60 ces-Consommation moyenne ajust\u00e9e": {
+          "sources": { "blsq": { "uids": ["jt5sDQ4CqWQ"] } },
+          "reconcile_options": {
+            "preferred_source": "blsq",
+            "data_type": "flux",
+            "impute": {},
+            "comments": [""]
+          }
+        },
+        "Data-EFV 600 mg - 30 ces-Consommation moyenne ajust\u00e9e": {
+          "sources": { "blsq": { "uids": ["lYuAeFMju4R"] } },
+          "reconcile_options": {
+            "preferred_source": "blsq",
+            "data_type": "flux",
+            "impute": {},
+            "comments": [""]
+          }
+        },
+        "Data-LPV/r 100/25 mg ces - 60 ces-Consommation moyenne ajust\u00e9e": {
+          "sources": { "blsq": { "uids": ["Z1Jz4BLyhwa"] } },
+          "reconcile_options": {
+            "preferred_source": "blsq",
+            "data_type": "flux",
+            "impute": {},
+            "comments": [""]
+          }
+        },
+        "Data-LPV/r 80/20 mg/ml solution orale - Fl. 60 ml-Consommation moyenne ajust\u00e9e": {
+          "sources": { "blsq": { "uids": ["Ef1j9aizOQx"] } },
+          "reconcile_options": {
+            "preferred_source": "blsq",
+            "data_type": "flux",
+            "impute": {},
+            "comments": [""]
+          }
+        },
+        "Data-LVP/r (133/33 mg) - 120 ces-Consommation moyenne ajust\u00e9e": {
+          "sources": { "blsq": { "uids": ["C8sKB4jQhF9"] } },
+          "reconcile_options": {
+            "preferred_source": "blsq",
+            "data_type": "flux",
+            "impute": {},
+            "comments": [""]
+          }
+        },
+        "Data-NVP 200 mg - 60 ces-Consommation moyenne ajust\u00e9e": {
+          "sources": { "blsq": { "uids": ["NPlgyBSw8uu"] } },
+          "reconcile_options": {
+            "preferred_source": "blsq",
+            "data_type": "flux",
+            "impute": {},
+            "comments": [""]
+          }
+        },
+        "Data-TDF 300 mg - 30 ces-Consommation moyenne ajust\u00e9e": {
+          "sources": { "blsq": { "uids": ["RHG92O0jpbG"] } },
+          "reconcile_options": {
+            "preferred_source": "blsq",
+            "data_type": "flux",
+            "impute": {},
+            "comments": [""]
+          }
+        },
+        "Data-TDF/3TC (300/300 mg) - 30 CES-Consommation moyenne ajust\u00e9e": {
+          "sources": { "blsq": { "uids": ["TduLijG7QLO"] } },
+          "reconcile_options": {
+            "preferred_source": "blsq",
+            "data_type": "flux",
+            "impute": {},
+            "comments": [""]
+          }
+        },
+        "Data-TDF/3TC/EFV (300/300/600 mg) - 30 ces-Consommation moyenne ajust\u00e9e": {
+          "sources": { "blsq": { "uids": ["HiERwOmAgjz"] } },
+          "reconcile_options": {
+            "preferred_source": "blsq",
+            "data_type": "flux",
+            "impute": {},
+            "comments": [""]
+          }
+        },
+        "Data-LPV/r (200/50 mg) - 12O ces-Consommation moyenne ajust\u00e9e": {
+          "sources": { "blsq": { "uids": ["WkeeJ5BzjCR"] } },
+          "reconcile_options": {
+            "preferred_source": "blsq",
+            "data_type": "flux",
+            "impute": {},
+            "comments": [""]
+          }
+        },
+        "Data-TDF/FTC (300/200 mg) - 30 ces-Consommation moyenne ajust\u00e9e": {
+          "sources": { "blsq": { "uids": ["lcQMOUBuDc5"] } },
+          "reconcile_options": {
+            "preferred_source": "blsq",
+            "data_type": "flux",
+            "impute": {},
+            "comments": [""]
+          }
+        },
+        "Data-NVP 50 mg ces pour solution orale - 60 C\u00e9s-Consommation moyenne ajust\u00e9e": {
+          "sources": { "blsq": { "uids": ["v9hr0FNP5ZV"] } },
+          "reconcile_options": {
+            "preferred_source": "blsq",
+            "data_type": "flux",
+            "impute": {},
+            "comments": [""]
+          }
+        },
+        "Data-LPV/r 80/20 mg/ml solution orale - Fl. 60 ml-Stockout": {
+          "sources": { "blsq": { "uids": ["LoQMve1V1l8"] } },
+          "reconcile_options": {
+            "preferred_source": "blsq",
+            "data_type": "flux",
+            "impute": {},
+            "comments": [""]
+          }
+        },
+        "Data-3TC 10 mg/ml solution orale - Fl. 240 ml-Stockout": {
+          "sources": { "blsq": { "uids": ["JtizQc3ItvD"] } },
+          "reconcile_options": {
+            "preferred_source": "blsq",
+            "data_type": "flux",
+            "impute": {},
+            "comments": [""]
+          }
+        },
+        "Data-3TC 150 mg - 60 ces-Stockout": {
+          "sources": { "blsq": { "uids": ["F1odQwWvLlM"] } },
+          "reconcile_options": {
+            "preferred_source": "blsq",
+            "data_type": "flux",
+            "impute": {},
+            "comments": [""]
+          }
+        },
+        "Data-TDF/FTC (300/200 mg) - 30 ces-Stockout": {
+          "sources": { "blsq": { "uids": ["vfBVUBSpqyO"] } },
+          "reconcile_options": {
+            "preferred_source": "blsq",
+            "data_type": "flux",
+            "impute": {},
+            "comments": [""]
+          }
+        },
+        "Data-TDF/3TC/EFV (300/300/600 mg) - 30 ces-Stockout": {
+          "sources": { "blsq": { "uids": ["hGCNPoGVKVN"] } },
+          "reconcile_options": {
+            "preferred_source": "blsq",
+            "data_type": "flux",
+            "impute": {},
+            "comments": [""]
+          }
+        },
+        "Data-TDF/3TC (300/300 mg) - 30 CES-Stockout": {
+          "sources": { "blsq": { "uids": ["uJwJ6MNvPDf"] } },
+          "reconcile_options": {
+            "preferred_source": "blsq",
+            "data_type": "flux",
+            "impute": {},
+            "comments": [""]
+          }
+        },
+        "Data-TDF 300 mg - 30 ces-Stockout": {
+          "sources": { "blsq": { "uids": ["XFwCquySY0I"] } },
+          "reconcile_options": {
+            "preferred_source": "blsq",
+            "data_type": "flux",
+            "impute": {},
+            "comments": [""]
+          }
+        },
+        "Data-NVP 50 mg ces pour solution orale - 60 C\u00e9s-Stockout": {
+          "sources": { "blsq": { "uids": ["IIhBVdKSRhK"] } },
+          "reconcile_options": {
+            "preferred_source": "blsq",
+            "data_type": "flux",
+            "impute": {},
+            "comments": [""]
+          }
+        },
+        "Data-NVP 200 mg - 60 ces-Stockout": {
+          "sources": { "blsq": { "uids": ["c2cqb8QtJ1S"] } },
+          "reconcile_options": {
+            "preferred_source": "blsq",
+            "data_type": "flux",
+            "impute": {},
+            "comments": [""]
+          }
+        },
+        "Data-LVP/r (133/33 mg) - 120 ces-Stockout": {
+          "sources": { "blsq": { "uids": ["LcnTFQ7pIX0"] } },
+          "reconcile_options": {
+            "preferred_source": "blsq",
+            "data_type": "flux",
+            "impute": {},
+            "comments": [""]
+          }
+        },
+        "Data-LPV/r 100/25 mg ces - 60 ces-Stockout": {
+          "sources": { "blsq": { "uids": ["XgCWDfRv5Rq"] } },
+          "reconcile_options": {
+            "preferred_source": "blsq",
+            "data_type": "flux",
+            "impute": {},
+            "comments": [""]
+          }
+        },
+        "Data-LPV/r (200/50 mg) - 12O ces-Stockout": {
+          "sources": { "blsq": { "uids": ["opaSTvEyLaW"] } },
+          "reconcile_options": {
+            "preferred_source": "blsq",
+            "data_type": "flux",
+            "impute": {},
+            "comments": [""]
+          }
+        },
+        "Data-EFV 600 mg - 30 ces-Stockout": {
+          "sources": { "blsq": { "uids": ["g7JxNzgGVEo"] } },
+          "reconcile_options": {
+            "preferred_source": "blsq",
+            "data_type": "flux",
+            "impute": {},
+            "comments": [""]
+          }
+        },
+        "Data-AZT/3TC/NVP 60/30/50 mg ces disp - 60 ces-Stockout": {
+          "sources": { "blsq": { "uids": ["Iiw7a7JBshL"] } },
+          "reconcile_options": {
+            "preferred_source": "blsq",
+            "data_type": "flux",
+            "impute": {},
+            "comments": [""]
+          }
+        },
+        "Data-AZT/3TC/NVP (300/150/200 mg) - 60 ces-Stockout": {
+          "sources": { "blsq": { "uids": ["d7bv8JQg5MM"] } },
+          "reconcile_options": {
+            "preferred_source": "blsq",
+            "data_type": "flux",
+            "impute": {},
+            "comments": [""]
+          }
+        },
+        "Data-AZT/3TC 60/30 mg ces disp - 60ces-Stockout": {
+          "sources": { "blsq": { "uids": ["aqvnaPyYDoY"] } },
+          "reconcile_options": {
+            "preferred_source": "blsq",
+            "data_type": "flux",
+            "impute": {},
+            "comments": [""]
+          }
+        },
+        "Data-AZT/3TC (300/150 mg) - 60 ces-Stockout": {
+          "sources": { "blsq": { "uids": ["Y7sG2cnO6V9"] } },
+          "reconcile_options": {
+            "preferred_source": "blsq",
+            "data_type": "flux",
+            "impute": {},
+            "comments": [""]
+          }
+        },
+        "Data-AZT 300 mg - 60 ces-Stockout": {
+          "sources": { "blsq": { "uids": ["IwiJuJrDzjL"] } },
+          "reconcile_options": {
+            "preferred_source": "blsq",
+            "data_type": "flux",
+            "impute": {},
+            "comments": [""]
+          }
+        },
+        "Data-ABC/3TC ( 300/150 mg) - 60 ces-Stockout": {
+          "sources": { "blsq": { "uids": ["k3yh51eXltE"] } },
+          "reconcile_options": {
+            "preferred_source": "blsq",
+            "data_type": "flux",
+            "impute": {},
+            "comments": [""]
+          }
+        },
+        "Data-ABC 60 mg disp - 60 ces-Stockout": {
+          "sources": { "blsq": { "uids": ["SPbj5ZEpF8F"] } },
+          "reconcile_options": {
+            "preferred_source": "blsq",
+            "data_type": "flux",
+            "impute": {},
+            "comments": [""]
+          }
+        },
+        "Data-ABC 300 mg - 60 ces-Stockout": {
+          "sources": { "blsq": { "uids": ["mvsxvsk4fTQ"] } },
+          "reconcile_options": {
+            "preferred_source": "blsq",
+            "data_type": "flux",
+            "impute": {},
+            "comments": [""]
+          }
+        },
+        "Data-ABC /3TC 60/30 mg disp. - 60ces-Stockout": {
+          "sources": { "blsq": { "uids": ["mZ4Xxqlyovd"] } },
+          "reconcile_options": {
+            "preferred_source": "blsq",
+            "data_type": "flux",
+            "impute": {},
+            "comments": [""]
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
this allow "raw data elements names" 
`Data-LVP/r (133/33 mg) - 120 ces-Consommation moyenne ajust\u00e9e`
to be turned in to
`data_lvp_r_133_33_mg_120_ces_consommation_moyenne_ajustee`


You can serialize back to json if needed
```python
config = Descriptor.load("./specs/fixtures/config/parametrized-raw")
jsonDescriptor = Descriptor.to_json(config)
```