### PR TITLE
Allow to extract orgunit structure outside airflow

### DIFF
--- a/blsqpy/dhis2.py
+++ b/blsqpy/dhis2.py
@@ -42,7 +42,7 @@ class Dhis2(object):
         # replace resources sql "SELECT organisationunituid, level, uidlevel1, uidlevel2, uidlevel3, uidlevel4, uidlevel5 FROM _orgunitstructure;")
         # by sql on orgunit and computation
         self.orgunitstructure = Levels.add_uid_levels_columns_from_path_column(
-            hook.get_pandas_df("SELECT uid as organisationunituid, path from organisationunit;"),
+            hook.get_pandas_df("SELECT uid as organisationunituid, path, name as organisationunitname from organisationunit;"),
             start=1, end_offset=2, with_level=True
         )
         self.categoryoptioncombo = hook.get_pandas_df(

--- a/specs/dhis2_spec.py
+++ b/specs/dhis2_spec.py
@@ -6,11 +6,10 @@ from blsqpy.descriptor import Descriptor
 from blsqpy.dhis2_dumper import Dhis2Dumper
 
 init_sql_to_df = {
-    "SELECT organisationunitid, uid, name, path FROM organisationunit;": {"file": "organisationunit"},
     "SELECT uid, name, dataelementid, categorycomboid FROM dataelement;": {"file": "dataelements"},
     "SELECT uid, name, dataelementgroupid FROM dataelementgroup;": {"file": "dataelementgroups"},
     "SELECT dataelementid, dataelementgroupid FROM dataelementgroupmembers;": {"file": "dataelementgroupmembers"},
-    "SELECT uid as organisationunituid, path from organisationunit;": {"file": "orgunits"},
+    "SELECT uid as organisationunituid, path, name as organisationunitname from organisationunit;": {"file": "orgunits"},
     "SELECT categoryoptioncomboid, name , uid FROM categoryoptioncombo;": {"file": "categoryoptioncombos"},
     "SELECT *  FROM categorycombos_optioncombos;": {"file": "cocs"},
 }
@@ -25,6 +24,7 @@ class MockHook:
         # print(self.sqls_to_dfs)
 
     def get_pandas_df(self, sql):
+        print(self.sqls_to_dfs.keys())
         csv = self.sqls_to_dfs[sql]
         #print(sql, csv)
 
@@ -146,4 +146,15 @@ with description('Dhis2') as self:
         expect(mock_s3.uploads).to(equal(
             ['bucket/export/play/extract_data_values_play_pills-raw.csv',
              'bucket/export/play/extract_data_values_play_pills'
+             ]))
+
+    with it("Dhis2Dumper.dumps"):
+        pg_hook = MockHook.with_extra_sqls({})
+        mock_s3 = MockS3Hook()
+
+        config = Descriptor.load("./specs/fixtures/config/dump")
+        dumper = Dhis2Dumper(config, mock_s3, "bucket", pg_hook=pg_hook)
+        dumper.dump_organisation_units_structure()
+        expect(mock_s3.uploads).to(equal(
+            ['bucket/export/play/organisation_units_structure.csv',
              ]))

--- a/specs/dhis2_spec.py
+++ b/specs/dhis2_spec.py
@@ -21,10 +21,8 @@ class MockHook:
         self.sqls_to_dfs = sqls_to_dfs
         self.conn_name_attr = "mock_conn"
         self.mock_conn = "mock_connection"
-        # print(self.sqls_to_dfs)
 
     def get_pandas_df(self, sql):
-        print(self.sqls_to_dfs.keys())
         csv = self.sqls_to_dfs[sql]
         #print(sql, csv)
 


### PR DESCRIPTION
add the name of the orgunit (lost in a previous refactoring to avoid analytics usage)

```
from blsqpy.dhis2_dumper import Dhis2Dumper
from blsqpy.s3export_hook import S3ExportsHook
from blsqpy.postgres_hook import PostgresHook
from blsqpy.descriptor import Descriptor
config = Descriptor.load("../docker-airflow-eb/dags/config/...")

s3_hook = S3ExportsHook("s3_readwrite")
dumper = Dhis2Dumper(config, s3_hook, "bucket")
dumper.dump_organisation_units_structure()
```
